### PR TITLE
Add fullscreen container

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -65,6 +65,9 @@
                 container:      null,
                 wrapper:        '.plyr__controls'
             },
+            fullscreen: {
+                container:      null,
+            },
             labels:             '[data-plyr]',
             buttons: {
                 seek:           '[data-plyr="seek"]',
@@ -122,8 +125,7 @@
         fullscreen: {
             enabled:            true,
             fallback:           true,
-            allowAudio:         false,
-            container:          null
+            allowAudio:         false
         },
         storage: {
             enabled:            true,
@@ -2108,7 +2110,7 @@
             }
 
             // Set class hook
-            _toggleClass(plyr.container, config.classes.fullscreen.active, plyr.isFullscreen);
+            _toggleClass(plyr.fullscreenContainer, config.classes.fullscreen.active, plyr.isFullscreen);
 
             // Trap focus
             _focusTrap(plyr.isFullscreen);
@@ -2119,7 +2121,7 @@
             }
 
             // Trigger an event
-            _triggerEvent(plyr.container, plyr.isFullscreen ? 'enterfullscreen' : 'exitfullscreen', true);
+            _triggerEvent(plyr.fullscreenContainer, plyr.isFullscreen ? 'enterfullscreen' : 'exitfullscreen', true);
 
             // Restore scroll position
             if (!plyr.isFullscreen && nativeSupport) {

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -122,7 +122,8 @@
         fullscreen: {
             enabled:            true,
             fallback:           true,
-            allowAudio:         false
+            allowAudio:         false,
+            container:          null
         },
         storage: {
             enabled:            true,
@@ -896,6 +897,14 @@
         function _setupFullscreen() {
             if (!plyr.supported.full) {
                 return;
+            }
+
+            // Setup specified fullscreen container from config (default is plyr.container)
+            if (_is.string(config.selectors.fullscreen.container)) {
+                plyr.fullscreenContainer = document.querySelector(config.selectors.fullscreen.container);
+            }
+            if (!_is.htmlElement(plyr.fullscreenContainer)) {
+                plyr.fullscreenContainer = plyr.container;
             }
 
             if ((plyr.type !== 'audio' || config.fullscreen.allowAudio) && config.fullscreen.enabled) {
@@ -2071,22 +2080,22 @@
             if (nativeSupport) {
                 // If it's a fullscreen change event, update the UI
                 if (event && event.type === fullscreen.fullScreenEventName) {
-                    plyr.isFullscreen = fullscreen.isFullScreen(plyr.container);
+                    plyr.isFullscreen = fullscreen.isFullScreen(plyr.fullscreenContainer);
                 } else {
                     // Else it's a user request to enter or exit
-                    if (!fullscreen.isFullScreen(plyr.container)) {
+                    if (!fullscreen.isFullScreen(plyr.fullscreenContainer)) {
                         // Save scroll position
                         _saveScrollPosition();
 
                         // Request full screen
-                        fullscreen.requestFullScreen(plyr.container);
+                        fullscreen.requestFullScreen(plyr.fullscreenContainer);
                     } else {
                         // Bail from fullscreen
                         fullscreen.cancelFullScreen();
                     }
 
                     // Check if we're actually full screen (it could fail)
-                    plyr.isFullscreen = fullscreen.isFullScreen(plyr.container);
+                    plyr.isFullscreen = fullscreen.isFullScreen(plyr.fullscreenContainer);
 
                     return;
                 }

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -2737,7 +2737,7 @@
                 }
 
                 // Restore class hooks
-                _toggleClass(plyr.container, config.classes.fullscreen.active, plyr.isFullscreen);
+                _toggleClass(plyr.fullscreenContainer, config.classes.fullscreen.active, plyr.isFullscreen);
                 _toggleClass(plyr.container, config.classes.captions.active, plyr.captionsEnabled);
                 _toggleStyleHook();
 

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -66,7 +66,7 @@
                 wrapper:        '.plyr__controls'
             },
             fullscreen: {
-                container:      null,
+                container:      null
             },
             labels:             '[data-plyr]',
             buttons: {
@@ -917,7 +917,7 @@
                     _log((nativeSupport ? 'Native' : 'Fallback') + ' fullscreen enabled');
 
                     // Add styling hook
-                    _toggleClass(plyr.container, config.classes.fullscreen.enabled, true);
+                    _toggleClass(plyr.fullscreenContainer, config.classes.fullscreen.enabled, true);
                 } else {
                     _log('Fullscreen not supported and fallback disabled');
                 }


### PR DESCRIPTION
新增一個 fullscreen.container 的 config 選項，讓 player 的 parent 可以被設為全螢幕的對象，以解決 countdown 無法在全螢幕顯示的問題。

For example:

```
<div class=".video-container">
	<!-- some other component for video -->
	<!-- original plyr container -->
</div>
```

Now I can use:

```
plyr.setup(element, {
	selectors: {
		fullscreen: {
			container: '.video-container'
		}
	}
});
```